### PR TITLE
Removed 54340_GemeindeLeiwen_Tennisplatz, added 54340_GemeindeLeiwen_ForumLiviaOffloader

### DIFF
--- a/seg_02/54340_GemeindeLeiwen_ForumLiviaOffloader
+++ b/seg_02/54340_GemeindeLeiwen_ForumLiviaOffloader
@@ -1,0 +1,3 @@
+# 54340_GemeindeLeiwen_ForumLiviaOffloader
+# 74:83:c2:f5:eb:26
+key "376efad0aa8e7d24b5395e0c19e47c609a56b408b48fc5495fb1f2dce9977b00";

--- a/seg_02/54340_GemeindeLeiwen_Tennisplatz
+++ b/seg_02/54340_GemeindeLeiwen_Tennisplatz
@@ -1,3 +1,0 @@
-# 54340_GemeindeLeiwen_Tennisplatz
-# 94:83:c4:00:56:b4
-key "20295c9a005d7c777a87853d4b79ae83b47d77743b35b9d5636f40b15561121e";


### PR DESCRIPTION
Der 54340_GemeindeLeiwen_Tennisplatz ist zu schwach und wurde wieder mit der original Firmware geflashed.